### PR TITLE
Add visitor for simplifying Boolean and bitvector expressions

### DIFF
--- a/GPUVerifyVCGen/ExpressionSimplifier.cs
+++ b/GPUVerifyVCGen/ExpressionSimplifier.cs
@@ -1,0 +1,84 @@
+//===-----------------------------------------------------------------------==//
+//
+//                GPUVerify - a Verifier for GPU Kernels
+//
+// This file is distributed under the Microsoft Public License.  See
+// LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+using System.Numerics;
+using System.Text.RegularExpressions;
+using Microsoft.Boogie;
+using Microsoft.Basetypes;
+
+namespace GPUVerify
+{
+    class ExpressionSimplifier : StandardVisitor {
+        Regex AndPattern = new Regex(@"^BV\d*_AND$");
+        Regex OrPattern = new Regex(@"^BV\d*_OR$");
+        Regex XorPattern = new Regex(@"^BV\d*_XOR$");
+        Regex ZextPattern = new Regex(@"^BV\d*_ZEXT\d*$");
+
+        private int GetBvBits(Expr node) {
+            return ((BvType)node.Type).Bits;
+        }
+
+        private BigInteger GetBigInt(Expr node) {
+            return ((BvConst)((LiteralExpr)node).Val).Value.ToBigInteger;
+        }
+
+        public override Expr VisitNAryExpr(NAryExpr node) {
+            // Simplify the children.
+            node = (NAryExpr)base.VisitNAryExpr(node);
+
+            // Simplify constant Boolean expressions and bit vector expressions
+            // that will occur in assertions when not all arrays are being
+            // checked for races. Bit vector expressions are ignored if they
+            // were modelled as mathematical integers.
+            if (node.Fun is BinaryOperator) {
+                var binOp = node.Fun as BinaryOperator;
+                if (binOp.Op == BinaryOperator.Opcode.Imp) {
+                    if (node.Args[0] is LiteralExpr) {
+                      return node.Args[0] == Expr.False ? Expr.True : node.Args[1];
+                    } else if (node.Args[1] is LiteralExpr) {
+                      return node.Args[1] == Expr.True ? Expr.True : node.Args[0];
+                    }
+                } else if (binOp.Op == BinaryOperator.Opcode.Neq) {
+                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                        return node.Args[0].Equals(node.Args[1]) ? Expr.False : Expr.True;
+                    }
+                } else if (binOp.Op == BinaryOperator.Opcode.Eq) {
+                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                        return node.Args[0].Equals(node.Args[1]) ? Expr.True : Expr.False;
+                    }
+                }
+            } else if (ZextPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                if (node.Args[0] is LiteralExpr && node.Type is BvType) {
+                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]));
+                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                }
+            } else if (XorPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) ^ GetBigInt(node.Args[1]));
+                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                }
+            } else if (AndPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) & GetBigInt(node.Args[1]));
+                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                }
+            } else if (OrPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) | GetBigInt(node.Args[1]));
+                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                }
+            } else if (node.Fun is IfThenElse) {
+                if (node.Args[0] is LiteralExpr) {
+                    return node.Args[0] == Expr.True ? node.Args[1] : node.Args[2];
+                }
+            }
+            return node;
+        }
+    }
+}

--- a/GPUVerifyVCGen/ExpressionSimplifier.cs
+++ b/GPUVerifyVCGen/ExpressionSimplifier.cs
@@ -14,71 +14,79 @@ using Microsoft.Basetypes;
 
 namespace GPUVerify
 {
-    class ExpressionSimplifier : StandardVisitor {
-        Regex AndPattern = new Regex(@"^BV\d*_AND$");
-        Regex OrPattern = new Regex(@"^BV\d*_OR$");
-        Regex XorPattern = new Regex(@"^BV\d*_XOR$");
-        Regex ZextPattern = new Regex(@"^BV\d*_ZEXT\d*$");
+    class ExpressionSimplifier {
 
-        private int GetBvBits(Expr node) {
-            return ((BvType)node.Type).Bits;
-        }
+        private class Simplifier : StandardVisitor {
+            private static Regex AndPattern = new Regex(@"^BV\d*_AND$");
+            private static Regex OrPattern = new Regex(@"^BV\d*_OR$");
+            private static Regex XorPattern = new Regex(@"^BV\d*_XOR$");
+            private static Regex ZextPattern = new Regex(@"^BV\d*_ZEXT\d*$");
 
-        private BigInteger GetBigInt(Expr node) {
-            return ((BvConst)((LiteralExpr)node).Val).Value.ToBigInteger;
-        }
-
-        public override Expr VisitNAryExpr(NAryExpr node) {
-            // Simplify the children.
-            node = (NAryExpr)base.VisitNAryExpr(node);
-
-            // Simplify constant Boolean expressions and bit vector expressions
-            // that will occur in assertions when not all arrays are being
-            // checked for races. Bit vector expressions are ignored if they
-            // were modelled as mathematical integers.
-            if (node.Fun is BinaryOperator) {
-                var binOp = node.Fun as BinaryOperator;
-                if (binOp.Op == BinaryOperator.Opcode.Imp) {
-                    if (node.Args[0] is LiteralExpr) {
-                      return node.Args[0] == Expr.False ? Expr.True : node.Args[1];
-                    } else if (node.Args[1] is LiteralExpr) {
-                      return node.Args[1] == Expr.True ? Expr.True : node.Args[0];
-                    }
-                } else if (binOp.Op == BinaryOperator.Opcode.Neq) {
-                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
-                        return node.Args[0].Equals(node.Args[1]) ? Expr.False : Expr.True;
-                    }
-                } else if (binOp.Op == BinaryOperator.Opcode.Eq) {
-                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
-                        return node.Args[0].Equals(node.Args[1]) ? Expr.True : Expr.False;
-                    }
-                }
-            } else if (ZextPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
-                if (node.Args[0] is LiteralExpr && node.Type is BvType) {
-                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]));
-                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
-                }
-            } else if (XorPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
-                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
-                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) ^ GetBigInt(node.Args[1]));
-                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
-                }
-            } else if (AndPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
-                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
-                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) & GetBigInt(node.Args[1]));
-                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
-                }
-            } else if (OrPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
-                if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
-                    var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) | GetBigInt(node.Args[1]));
-                    return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
-                }
-            } else if (node.Fun is IfThenElse) {
-                if (node.Args[0] is LiteralExpr) {
-                    return node.Args[0] == Expr.True ? node.Args[1] : node.Args[2];
-                }
+            private static int GetBvBits(Expr node) {
+                return ((BvType)node.Type).Bits;
             }
-            return node;
+
+            private static BigInteger GetBigInt(Expr node) {
+                return ((BvConst)((LiteralExpr)node).Val).Value.ToBigInteger;
+            }
+
+            public override Expr VisitNAryExpr(NAryExpr node) {
+                // Simplify the children.
+                node = (NAryExpr)base.VisitNAryExpr(node);
+
+                // Simplify constant Boolean and bitvector expressions that
+                // occur in assertions when not all arrays are being checked
+                // for races. Bitvector expressions are ignored if they were
+                // modelled as mathematical integers.
+                if (node.Fun is BinaryOperator) {
+                    var binOp = node.Fun as BinaryOperator;
+                    if (binOp.Op == BinaryOperator.Opcode.Imp) {
+                        if (node.Args[0] is LiteralExpr) {
+                            return node.Args[0] == Expr.False ? Expr.True : node.Args[1];
+                        } else if (node.Args[1] is LiteralExpr) {
+                            return node.Args[1] == Expr.True ? Expr.True : node.Args[0];
+                        }
+                    } else if (binOp.Op == BinaryOperator.Opcode.Neq) {
+                        if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                            return node.Args[0].Equals(node.Args[1]) ? Expr.False : Expr.True;
+                        }
+                    } else if (binOp.Op == BinaryOperator.Opcode.Eq) {
+                        if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                            return node.Args[0].Equals(node.Args[1]) ? Expr.True : Expr.False;
+                        }
+                    }
+                } else if (ZextPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                    if (node.Args[0] is LiteralExpr && node.Type is BvType) {
+                        var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]));
+                        return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                    }
+                } else if (XorPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                        var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) ^ GetBigInt(node.Args[1]));
+                        return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                    }
+                } else if (AndPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                        var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) & GetBigInt(node.Args[1]));
+                        return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                    }
+                } else if (OrPattern.Match(node.Fun.FunctionName).Success && node.Type is BvType) {
+                    if (node.Args[0] is LiteralExpr && node.Args[1] is LiteralExpr) {
+                        var NewVal = BigNum.FromBigInt(GetBigInt(node.Args[0]) | GetBigInt(node.Args[1]));
+                        return new LiteralExpr(Token.NoToken, NewVal, GetBvBits(node));
+                    }
+                } else if (node.Fun is IfThenElse) {
+                    if (node.Args[0] is LiteralExpr) {
+                        return node.Args[0] == Expr.True ? node.Args[1] : node.Args[2];
+                    }
+                }
+                return node;
+            }
+        }
+
+        public static void Simplify(Program program) {
+            var ExprSimplify = new Simplifier();
+            ExprSimplify.Visit(program);
         }
     }
 }

--- a/GPUVerifyVCGen/GPUVerifier.cs
+++ b/GPUVerifyVCGen/GPUVerifier.cs
@@ -2647,8 +2647,7 @@ namespace GPUVerify
                 x => VariablesToEliminate.Contains(x) ? (Expr)Expr.False : (Expr)Expr.Ident(x), c)).ToList();
             }
 
-            var ExprSimplify = new ExpressionSimplifier();
-            ExprSimplify.Visit(Program);
+            ExpressionSimplifier.Simplify(Program);
           }
 
         }

--- a/GPUVerifyVCGen/GPUVerifier.cs
+++ b/GPUVerifyVCGen/GPUVerifier.cs
@@ -2646,6 +2646,9 @@ namespace GPUVerify
               b.cmds = b.cmds.Select(c => Substituter.Apply(
                 x => VariablesToEliminate.Contains(x) ? (Expr)Expr.False : (Expr)Expr.Ident(x), c)).ToList();
             }
+
+            var ExprSimplify = new ExpressionSimplifier();
+            ExprSimplify.Visit(Program);
           }
 
         }

--- a/GPUVerifyVCGen/GPUVerifyVCGen.csproj
+++ b/GPUVerifyVCGen/GPUVerifyVCGen.csproj
@@ -114,6 +114,7 @@
     <Compile Include="WatchdogRaceInstrumenter.cs" />
     <Compile Include="WriteCollector.cs" />
     <Compile Include="ConstantWriteCollector.cs" />
+    <Compile Include="ExpressionSimplifier.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/testsuite/OpenCL/expression_simplification/and_test/kernel.cl
+++ b/testsuite/OpenCL/expression_simplification/and_test/kernel.cl
@@ -1,0 +1,16 @@
+//xfail:NOT_ALL_VERIFIED
+//--local_size=256 --num_groups=2 --vcgen-op=/checkArrays:A --infer-info
+//Houdini assignment axiom: true
+//error: this assertion might not hold
+
+__kernel void test(__global double *A, __global double *B) {
+  A[get_global_id(0)] = 0;
+
+  for (int i = 0;
+       __invariant(__implies(i > 0, !__write(B) & !__write(B))),
+       i < 42; ++i) {
+    B[i] = get_global_id(0);
+  }
+
+  __assert(false);
+}

--- a/testsuite/OpenCL/expression_simplification/basic_test/kernel.cl
+++ b/testsuite/OpenCL/expression_simplification/basic_test/kernel.cl
@@ -1,0 +1,16 @@
+//xfail:NOT_ALL_VERIFIED
+//--local_size=256 --num_groups=2 --vcgen-op=/checkArrays:A --infer-info
+//Houdini assignment axiom: true
+//error: this assertion might not hold
+
+__kernel void test(__global double *A, __global double *B) {
+  A[get_global_id(0)] = 0;
+
+  for (int i = 0;
+       __invariant(!__write(B)),
+       i < 42; ++i) {
+    B[i] = get_global_id(0);
+  }
+
+  __assert(false);
+}

--- a/testsuite/OpenCL/expression_simplification/imp_antecedent/kernel.cl
+++ b/testsuite/OpenCL/expression_simplification/imp_antecedent/kernel.cl
@@ -1,0 +1,16 @@
+//xfail:NOT_ALL_VERIFIED
+//--local_size=256 --num_groups=2 --vcgen-op=/checkArrays:A --infer-info
+//Houdini assignment axiom: true
+//error: this assertion might not hold
+
+__kernel void test(__global double *A, __global double *B) {
+  A[get_global_id(0)] = 0;
+
+  for (int i = 0;
+       __invariant(__implies(__write(B), i > 0)),
+       i < 42; ++i) {
+    B[i] = get_global_id(0);
+  }
+
+  __assert(false);
+}

--- a/testsuite/OpenCL/expression_simplification/imp_consequent/kernel.cl
+++ b/testsuite/OpenCL/expression_simplification/imp_consequent/kernel.cl
@@ -1,0 +1,16 @@
+//xfail:NOT_ALL_VERIFIED
+//--local_size=256 --num_groups=2 --vcgen-op=/checkArrays:A --infer-info
+//Houdini assignment axiom: true
+//error: this assertion might not hold
+
+__kernel void test(__global double *A, __global double *B) {
+  A[get_global_id(0)] = 0;
+
+  for (int i = 0;
+       __invariant(__implies(i > 0, !__write(B))),
+       i < 42; ++i) {
+    B[i] = get_global_id(0);
+  }
+
+  __assert(false);
+}

--- a/testsuite/OpenCL/expression_simplification/or_test/kernel.cl
+++ b/testsuite/OpenCL/expression_simplification/or_test/kernel.cl
@@ -1,0 +1,16 @@
+//xfail:NOT_ALL_VERIFIED
+//--local_size=256 --num_groups=2 --vcgen-op=/checkArrays:A --infer-info
+//Houdini assignment axiom: true
+//error: this assertion might not hold
+
+__kernel void test(__global double *A, __global double *B) {
+  A[get_global_id(0)] = 0;
+
+  for (int i = 0;
+       __invariant(__implies(i > 0, !__write(B) | !__write(B))),
+       i < 42; ++i) {
+    B[i] = get_global_id(0);
+  }
+
+  __assert(false);
+}


### PR DESCRIPTION
When a loop has a manually specified invariant, we speculate
additional invariants irrespective of whether array access
checks occur in the loop. Under normal circumstances this
should be rare, and speculating invariants might still help
to prove the user provided ones.

When race checking is disabled for some arrays, the above situation
might might have a negative impact on verification performance:
Invariants might be speculated for loops that have manually supplied
invariants referring only to arrays for which race checking has been
disabled. These speculated invariants need to be considered by Houdini,
and since some speculated invariants state facts not related to array
accesses substantial effort might be involved.

To mitigate the above situation we simplify Boolean and bitvector
expressions that commonly occur in manually provided invariants.
The hope is that the invariants are reduced to just "true", which
stops additional invariants from being speculated.

@afd This has been in my tree for a long while. I recall that you may
have had some different ideas of addressing what is described above.