### PR TITLE
Add StyleCop.Analyzers support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ utils/GPUVerifyRise4Fun/*-counter.pickle
 
 # GPUVerify error report dump
 __gvdump.txt
+
+# NuGet
+packages/*

--- a/.travis/build_gpuverify.sh
+++ b/.travis/build_gpuverify.sh
@@ -2,5 +2,6 @@
 set -ev
 
 cd ${GPUVERIFY_DIR}
+nuget restore GPUVerify.sln
 msbuild /m /p:Configuration=Release GPUVerify.sln
 cp gvfindtools.templates/gvfindtools.travis.py gvfindtools.py

--- a/.travis/build_gpuverify.sh
+++ b/.travis/build_gpuverify.sh
@@ -2,5 +2,5 @@
 set -ev
 
 cd ${GPUVERIFY_DIR}
-xbuild /p:Configuration=Release GPUVerify.sln
+msbuild /m /p:Configuration=Release GPUVerify.sln
 cp gvfindtools.templates/gvfindtools.travis.py gvfindtools.py

--- a/.travis/build_gpuverify.sh
+++ b/.travis/build_gpuverify.sh
@@ -3,5 +3,6 @@ set -ev
 
 cd ${GPUVERIFY_DIR}
 nuget restore GPUVerify.sln
-msbuild /m /p:Configuration=Release GPUVerify.sln
+msbuild /m /p:Configuration=Release \
+  /p:CodeAnalysisRuleSet=$PWD/StyleCop.ruleset GPUVerify.sln
 cp gvfindtools.templates/gvfindtools.travis.py gvfindtools.py

--- a/Documentation/developer_guide.rst
+++ b/Documentation/developer_guide.rst
@@ -146,7 +146,7 @@ Replace as appropriate or setup an environment variable.::
      $ cd ${BUILD_ROOT}
      $ git clone https://github.com/mc-imperial/gpuverify.git
      $ cd ${BUILD_ROOT}/gpuverify
-     $ xbuild /p:Configuration=Release GPUVerify.sln
+     $ msbuild /m /p:Configuration=Release GPUVerify.sln
 
 #. Configure GPUVerify front end.
    GPUVerify uses a front end python script (GPUVerify.py). This script needs
@@ -478,7 +478,7 @@ in GPUVerify then follow the steps below for Linux and Mac OS X.::
       $ git clone https://github.com/boogie-org/boogie.git
       $ cd boogie/Source
       $ nuget restore Boogie.sln
-      $ xbuild /p:Configuration=Release Boogie.sln
+      $ msbuild /m /p:Configuration=Release Boogie.sln
       $ cd ../Binaries
       $ ls ${BUILD_ROOT}/gpuverify/BoogieBinaries \
              | xargs -I{} -t cp {} ${BUILD_ROOT}/gpuverify/BoogieBinaries

--- a/Documentation/developer_guide.rst
+++ b/Documentation/developer_guide.rst
@@ -146,6 +146,7 @@ Replace as appropriate or setup an environment variable.::
      $ cd ${BUILD_ROOT}
      $ git clone https://github.com/mc-imperial/gpuverify.git
      $ cd ${BUILD_ROOT}/gpuverify
+     $ nuget restore GPUVerify.sln
      $ msbuild /m /p:Configuration=Release GPUVerify.sln
 
 #. Configure GPUVerify front end.
@@ -360,8 +361,11 @@ drives.
    Microsoft tools for the command line, then::
 
       > cd ${BUILD_ROOT}
+      > $nuget_url = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+      > (new-object System.Net.WebClient).DownloadFile($nuget_url, "${BUILD_ROOT}\nuget.exe")
       > git clone https://github.com/mc-imperial/gpuverify.git
       > cd ${BUILD_ROOT}\gpuverify
+      > ${BUILD_ROOT}\nuget restore GPUVerify.sln
       > msbuild /p:Configuration=Release GPUVerify.sln
 
 #. Configure GPUVerify front end::

--- a/Documentation/developer_guide.rst
+++ b/Documentation/developer_guide.rst
@@ -147,7 +147,10 @@ Replace as appropriate or setup an environment variable.::
      $ git clone https://github.com/mc-imperial/gpuverify.git
      $ cd ${BUILD_ROOT}/gpuverify
      $ nuget restore GPUVerify.sln
-     $ msbuild /m /p:Configuration=Release GPUVerify.sln
+     $ msbuild /m \
+               /p:Configuration=Release \
+               /p:CodeAnalysisRuleSet=$PWD/StyleCop.ruleset
+               GPUVerify.sln
 
 #. Configure GPUVerify front end.
    GPUVerify uses a front end python script (GPUVerify.py). This script needs

--- a/Documentation/developer_guide.rst
+++ b/Documentation/developer_guide.rst
@@ -369,7 +369,9 @@ drives.
       > git clone https://github.com/mc-imperial/gpuverify.git
       > cd ${BUILD_ROOT}\gpuverify
       > ${BUILD_ROOT}\nuget restore GPUVerify.sln
-      > msbuild /p:Configuration=Release GPUVerify.sln
+      > msbuild /p:Configuration=Release `
+                /p:CodeAnalysisRuleSet=$PWD\StyleCop.ruleset `
+                GPUVerify.sln
 
 #. Configure GPUVerify front end::
 

--- a/GPUVerifyBoogieDriver/GPUVerifyBoogieDriver.csproj
+++ b/GPUVerifyBoogieDriver/GPUVerifyBoogieDriver.csproj
@@ -74,6 +74,13 @@
       <Name>GPUVerifyLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="Clean">
     <RemoveDir Directories="$(ProjectDir)\bin" />

--- a/GPUVerifyBoogieDriver/GPUVerifyBoogieDriver.csproj
+++ b/GPUVerifyBoogieDriver/GPUVerifyBoogieDriver.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/GPUVerifyBoogieDriver/packages.config
+++ b/GPUVerifyBoogieDriver/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/GPUVerifyCruncher/GPUVerifyCruncher.csproj
+++ b/GPUVerifyCruncher/GPUVerifyCruncher.csproj
@@ -86,7 +86,13 @@
       <HintPath>..\BoogieBinaries\BoogieGraph.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
   <Target Name="Clean">
     <RemoveDir Directories="$(ProjectDir)\bin" />
     <RemoveDir Directories="$(ProjectDir)\obj" />

--- a/GPUVerifyCruncher/GPUVerifyCruncher.csproj
+++ b/GPUVerifyCruncher/GPUVerifyCruncher.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/GPUVerifyCruncher/packages.config
+++ b/GPUVerifyCruncher/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/GPUVerifyLib/GPUVerifyLib.csproj
+++ b/GPUVerifyLib/GPUVerifyLib.csproj
@@ -85,6 +85,13 @@
     <Compile Include="VariablesOccurringInExpressionVisitor.cs" />
     <Compile Include="ToolExitCodes.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
   <Target Name="Clean">
     <RemoveDir Directories="$(ProjectDir)\bin" />
     <RemoveDir Directories="$(ProjectDir)\obj" />

--- a/GPUVerifyLib/GPUVerifyLib.csproj
+++ b/GPUVerifyLib/GPUVerifyLib.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/GPUVerifyLib/packages.config
+++ b/GPUVerifyLib/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/GPUVerifyVCGen/GPUVerifyVCGen.csproj
+++ b/GPUVerifyVCGen/GPUVerifyVCGen.csproj
@@ -128,4 +128,11 @@
       <Name>GPUVerifyLib</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
 </Project>

--- a/GPUVerifyVCGen/GPUVerifyVCGen.csproj
+++ b/GPUVerifyVCGen/GPUVerifyVCGen.csproj
@@ -21,6 +21,7 @@
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>..\Binaries\</OutputPath>
@@ -31,6 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CodeAnalysisRuleSet>..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Basetypes">

--- a/GPUVerifyVCGen/packages.config
+++ b/GPUVerifyVCGen/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -3,7 +3,16 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1005" Action="None" />
     <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1405" Action="None" />
     <Rule Id="SA1503" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1601" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1617" Action="None" />
+    <Rule Id="SA1618" Action="None" />
+    <Rule Id="SA1619" Action="None" />
     <Rule Id="SA1633" Action="None" />
     <Rule Id="SA1652" Action="None" />
   </Rules>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -3,6 +3,11 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1005" Action="None" />
     <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1203" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1402" Action="None" />
     <Rule Id="SA1405" Action="None" />
     <Rule Id="SA1503" Action="None" />
     <Rule Id="SA1600" Action="None" />

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="New Rule Set" Description=" " ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1005" Action="None" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1503" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+</RuleSet>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -1,24 +1,168 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="New Rule Set" Description=" " ToolsVersion="14.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1000" Action="Error" />
+    <Rule Id="SA1001" Action="Error" />
+    <Rule Id="SA1002" Action="Error" />
+    <Rule Id="SA1003" Action="Error" />
+    <Rule Id="SA1004" Action="Error" />
     <Rule Id="SA1005" Action="None" />
+    <Rule Id="SA1006" Action="Error" />
+    <Rule Id="SA1007" Action="Error" />
+    <Rule Id="SA1008" Action="Error" />
+    <Rule Id="SA1009" Action="Error" />
+    <Rule Id="SA1010" Action="Error" />
+    <Rule Id="SA1011" Action="Error" />
+    <Rule Id="SA1012" Action="Error" />
+    <Rule Id="SA1013" Action="Error" />
+    <Rule Id="SA1014" Action="Error" />
+    <Rule Id="SA1015" Action="Error" />
+    <Rule Id="SA1016" Action="Error" />
+    <Rule Id="SA1017" Action="Error" />
+    <Rule Id="SA1018" Action="Error" />
+    <Rule Id="SA1019" Action="Error" />
+    <Rule Id="SA1020" Action="Error" />
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
+    <Rule Id="SA1023" Action="Error" />
+    <Rule Id="SA1024" Action="Error" />
+    <Rule Id="SA1025" Action="Error" />
+    <Rule Id="SA1026" Action="Error" />
+    <Rule Id="SA1027" Action="Error" />
+    <Rule Id="SA1028" Action="Error" />
+    <Rule Id="SA1100" Action="Error" />
     <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1102" Action="Error" />
+    <Rule Id="SA1103" Action="Error" />
+    <Rule Id="SA1104" Action="Error" />
+    <Rule Id="SA1105" Action="Error" />
+    <Rule Id="SA1106" Action="Error" />
+    <Rule Id="SA1107" Action="Error" />
+    <Rule Id="SA1108" Action="Error" />
+    <Rule Id="SA1110" Action="Error" />
+    <Rule Id="SA1111" Action="Error" />
+    <Rule Id="SA1112" Action="Error" />
+    <Rule Id="SA1113" Action="Error" />
+    <Rule Id="SA1114" Action="Error" />
+    <Rule Id="SA1115" Action="Error" />
+    <Rule Id="SA1116" Action="Error" />
+    <Rule Id="SA1117" Action="Error" />
+    <Rule Id="SA1118" Action="Error" />
+    <Rule Id="SA1119" Action="Error" />
+    <Rule Id="SA1120" Action="Error" />
+    <Rule Id="SA1121" Action="Error" />
+    <Rule Id="SA1122" Action="Error" />
+    <Rule Id="SA1123" Action="Error" />
+    <Rule Id="SA1124" Action="Error" />
+    <Rule Id="SA1125" Action="Error" />
+    <Rule Id="SA1127" Action="Error" />
+    <Rule Id="SA1128" Action="Error" />
+    <Rule Id="SA1129" Action="Error" />
+    <Rule Id="SA1130" Action="Error" />
+    <Rule Id="SA1131" Action="Error" />
+    <Rule Id="SA1132" Action="Error" />
+    <Rule Id="SA1133" Action="Error" />
+    <Rule Id="SA1134" Action="Error" />
+    <Rule Id="SA1200" Action="Error" />
     <Rule Id="SA1201" Action="None" />
     <Rule Id="SA1202" Action="None" />
     <Rule Id="SA1203" Action="None" />
     <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1205" Action="Error" />
+    <Rule Id="SA1206" Action="Error" />
+    <Rule Id="SA1207" Action="Error" />
+    <Rule Id="SA1208" Action="Error" />
+    <Rule Id="SA1209" Action="Error" />
+    <Rule Id="SA1210" Action="Error" />
+    <Rule Id="SA1211" Action="Error" />
+    <Rule Id="SA1212" Action="Error" />
+    <Rule Id="SA1213" Action="Error" />
+    <Rule Id="SA1214" Action="Error" />
+    <Rule Id="SA1216" Action="Error" />
+    <Rule Id="SA1217" Action="Error" />
+    <Rule Id="SA1300" Action="Error" />
+    <Rule Id="SA1302" Action="Error" />
+    <Rule Id="SA1303" Action="Error" />
+    <Rule Id="SA1304" Action="Error" />
+    <Rule Id="SA1306" Action="Error" />
+    <Rule Id="SA1307" Action="Error" />
+    <Rule Id="SA1308" Action="Error" />
+    <Rule Id="SA1309" Action="Error" />
+    <Rule Id="SA1310" Action="Error" />
+    <Rule Id="SA1311" Action="Error" />
+    <Rule Id="SA1312" Action="Error" />
+    <Rule Id="SA1313" Action="Error" />
+    <Rule Id="SA1400" Action="Error" />
+    <Rule Id="SA1401" Action="Error" />
     <Rule Id="SA1402" Action="None" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
     <Rule Id="SA1405" Action="None" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1408" Action="Error" />
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
+    <Rule Id="SA1500" Action="Error" />
+    <Rule Id="SA1501" Action="Error" />
+    <Rule Id="SA1502" Action="Error" />
     <Rule Id="SA1503" Action="None" />
+    <Rule Id="SA1504" Action="Error" />
+    <Rule Id="SA1505" Action="Error" />
+    <Rule Id="SA1506" Action="Error" />
+    <Rule Id="SA1507" Action="Error" />
+    <Rule Id="SA1508" Action="Error" />
+    <Rule Id="SA1509" Action="Error" />
+    <Rule Id="SA1510" Action="Error" />
+    <Rule Id="SA1511" Action="Error" />
+    <Rule Id="SA1512" Action="Error" />
+    <Rule Id="SA1513" Action="Error" />
+    <Rule Id="SA1514" Action="Error" />
+    <Rule Id="SA1515" Action="Error" />
+    <Rule Id="SA1516" Action="Error" />
+    <Rule Id="SA1517" Action="Error" />
+    <Rule Id="SA1518" Action="Error" />
+    <Rule Id="SA1519" Action="Error" />
+    <Rule Id="SA1520" Action="Error" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1601" Action="None" />
     <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1604" Action="Error" />
+    <Rule Id="SA1605" Action="Error" />
+    <Rule Id="SA1606" Action="Error" />
+    <Rule Id="SA1607" Action="Error" />
+    <Rule Id="SA1608" Action="Error" />
+    <Rule Id="SA1610" Action="Error" />
     <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1612" Action="Error" />
+    <Rule Id="SA1613" Action="Error" />
+    <Rule Id="SA1614" Action="Error" />
     <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1616" Action="Error" />
     <Rule Id="SA1617" Action="None" />
     <Rule Id="SA1618" Action="None" />
     <Rule Id="SA1619" Action="None" />
+    <Rule Id="SA1620" Action="Error" />
+    <Rule Id="SA1621" Action="Error" />
+    <Rule Id="SA1622" Action="Error" />
+    <Rule Id="SA1623" Action="Error" />
+    <Rule Id="SA1624" Action="Error" />
+    <Rule Id="SA1625" Action="Error" />
+    <Rule Id="SA1626" Action="Error" />
+    <Rule Id="SA1627" Action="Error" />
     <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1634" Action="Error" />
+    <Rule Id="SA1635" Action="Error" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1637" Action="Error" />
+    <Rule Id="SA1638" Action="Error" />
+    <Rule Id="SA1640" Action="Error" />
+    <Rule Id="SA1641" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
+    <Rule Id="SA1648" Action="Error" />
+    <Rule Id="SA1649" Action="Error" />
+    <Rule Id="SA1651" Action="Error" />
     <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
StyleCop.Analyzers is the moral successor of StyleCop.

I disabled a number of warnings:
* Missing copyright header (our default copyright header is not detected)
* Require a space after `//` (this does not work with our copyright header)
* Enable the generation of XML documentation (there's hardly any in the code base)
* Always require `this` when accessing a member of the current class (we generally do not do this and does not seem worth fixing)
* Always require braces for compound statements (there are quite a few places where we violate this rule, and I do not think it always improves readability of the code)

Feel free to disagree with the above.

Even with the above rules disabled, we get about 2700 warnings (after having fixed around the same number already).