### PR TITLE
Fix power-of-2 invariants for arbitrary bitwidths and speculate relational invariants for 64-bit bitwidths

### DIFF
--- a/GPUVerifyVCGen/ArrayBoundsChecker.cs
+++ b/GPUVerifyVCGen/ArrayBoundsChecker.cs
@@ -158,9 +158,11 @@ namespace GPUVerify
             switch (btype)
             {
                 case BOUND_TYPE.LOWER:
-                    boundExpr = verifier.IntRep.MakeSge(offsetVarExpr, verifier.IntRep.GetLiteral(0, verifier.SizeTBits)); break;
+                    boundExpr = verifier.IntRep.MakeSge(offsetVarExpr, verifier.IntRep.GetZero(verifier.SizeTType));
+                    break;
                 case BOUND_TYPE.UPPER:
-                    boundExpr = verifier.IntRep.MakeSlt(offsetVarExpr, verifier.IntRep.GetLiteral(arrDim, verifier.SizeTBits)); break;
+                    boundExpr = verifier.IntRep.MakeSlt(offsetVarExpr, verifier.IntRep.GetLiteral(arrDim, verifier.SizeTType));
+                    break;
             }
 
             var key = new QKeyValue(Token.NoToken, "array_name", new List<object> { ar.V.Name }, null);

--- a/GPUVerifyVCGen/BarrierIntervalsAnalysis.cs
+++ b/GPUVerifyVCGen/BarrierIntervalsAnalysis.cs
@@ -150,12 +150,12 @@ namespace GPUVerify
             Debug.Assert(c.Ins.Count() == 2);
             if (strength == BarrierStrength.GROUP_SHARED || strength == BarrierStrength.ALL)
             {
-                if (!c.Ins[0].Equals(verifier.IntRep.GetLiteral(1, 1)))
+                if (!c.Ins[0].Equals(verifier.IntRep.GetLiteral(1, verifier.IntRep.GetIntType(1))))
                     return false;
             }
             else if (strength == BarrierStrength.GLOBAL || strength == BarrierStrength.ALL)
             {
-                if (!c.Ins[1].Equals(verifier.IntRep.GetLiteral(1, 1)))
+                if (!c.Ins[1].Equals(verifier.IntRep.GetLiteral(1, verifier.IntRep.GetIntType(1))))
                     return false;
             }
             else

--- a/GPUVerifyVCGen/BarrierInvariantDescriptor.cs
+++ b/GPUVerifyVCGen/BarrierInvariantDescriptor.cs
@@ -71,7 +71,7 @@ namespace GPUVerify
         protected Expr NonNegative(Expr e)
         {
             return Dualiser.Verifier.IntRep.MakeSge(
-              e, Verifier.Zero(Verifier.SizeTBits));
+              e, Verifier.IntRep.GetZero(Verifier.SizeTType));
         }
 
         protected Expr NotTooLarge(Expr e)

--- a/GPUVerifyVCGen/KernelDualiser.cs
+++ b/GPUVerifyVCGen/KernelDualiser.cs
@@ -152,7 +152,7 @@ namespace GPUVerify
                     Debug.Assert(call.Ins.Count >= (2 + (Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1)));
                     var biDescriptor = new UnaryBarrierInvariantDescriptor(
                         Verifier.UniformityAnalyser.IsUniform(call.callee) ? Expr.True : call.Ins[0],
-                        Expr.Neq(call.Ins[Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1], Verifier.Zero(1)),
+                        Expr.Neq(call.Ins[Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1], Verifier.IntRep.GetZero(Verifier.IntRep.GetIntType(1))),
                         call.Attributes,
                         this,
                         procName,
@@ -172,7 +172,7 @@ namespace GPUVerify
                     Debug.Assert(call.Ins.Count >= (3 + (Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1)));
                     var biDescriptor = new BinaryBarrierInvariantDescriptor(
                         Verifier.UniformityAnalyser.IsUniform(call.callee) ? Expr.True : call.Ins[0],
-                        Expr.Neq(call.Ins[Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1], Verifier.Zero(1)),
+                        Expr.Neq(call.Ins[Verifier.UniformityAnalyser.IsUniform(call.callee) ? 0 : 1], Verifier.IntRep.GetZero(Verifier.IntRep.GetIntType(1))),
                         call.Attributes,
                         this,
                         procName,

--- a/GPUVerifyVCGen/LoopInvariantGenerator.cs
+++ b/GPUVerifyVCGen/LoopInvariantGenerator.cs
@@ -294,7 +294,7 @@ namespace GPUVerify
                             var sub = verifier.IntRep.MakeSub(new IdentifierExpr(Token.NoToken, v), rhs as Expr);
                             List<Expr> args = new List<Expr>();
                             args.Add(sub);
-                            Function otherbv = verifier.FindOrCreateOther(sub.Type.BvBits);
+                            Function otherbv = verifier.FindOrCreateOther(sub.Type);
                             var inv = Expr.Eq(sub, new NAryExpr(Token.NoToken, new FunctionCall(otherbv), args));
                             verifier.AddCandidateInvariant(region, inv, "guardMinusInitialIsUniform");
                             var groupInv = Expr.Imp(verifier.ThreadsInSameGroup(), inv);
@@ -332,10 +332,10 @@ namespace GPUVerify
             foreach (var v in nonnegVars)
             {
                 // REVISIT: really we only want to guess for /integer/ variables.
-                int bvWidth = v.TypedIdent.Type.BvBits;
-                if (bvWidth >= 8)
+                var type = v.TypedIdent.Type;
+                if (type.BvBits >= 8)
                 {
-                    var inv = verifier.IntRep.MakeSle(verifier.Zero(bvWidth), new IdentifierExpr(v.tok, v));
+                    var inv = verifier.IntRep.MakeSle(verifier.IntRep.GetZero(type), new IdentifierExpr(v.tok, v));
                     verifier.AddCandidateInvariant(region, inv, "guardNonNeg");
                 }
             }

--- a/GPUVerifyVCGen/OriginalRaceInstrumenter.cs
+++ b/GPUVerifyVCGen/OriginalRaceInstrumenter.cs
@@ -36,13 +36,13 @@ namespace GPUVerify
             Variable accessHasOccurredVariable =
                 GPUVerifier.MakeAccessHasOccurredVariable(v.Name, access);
             Variable accessOffsetVariable =
-                RaceInstrumentationUtil.MakeOffsetVariable(v.Name, access, Verifier.IntRep.GetIntType(Verifier.SizeTBits));
+                RaceInstrumentationUtil.MakeOffsetVariable(v.Name, access, Verifier.SizeTType);
             Variable accessValueVariable =
                 RaceInstrumentationUtil.MakeValueVariable(v.Name, access, mt.Result);
             Variable accessBenignFlagVariable =
                 GPUVerifier.MakeBenignFlagVariable(v.Name);
             Variable accessAsyncHandleVariable =
-                RaceInstrumentationUtil.MakeAsyncHandleVariable(v.Name, access, Verifier.IntRep.GetIntType(Verifier.SizeTBits));
+                RaceInstrumentationUtil.MakeAsyncHandleVariable(v.Name, access, Verifier.SizeTType);
 
             Variable predicateParameter =
                 new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_P", Type.Bool));
@@ -53,7 +53,7 @@ namespace GPUVerify
             Variable valueOldParameter =
                 new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_value_old", mt.Result));
             Variable asyncHandleParameter =
-                new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_async_handle", Verifier.IntRep.GetIntType(Verifier.SizeTBits)));
+                new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_async_handle", Verifier.SizeTType));
 
             Debug.Assert(!(mt.Result is MapType));
 

--- a/GPUVerifyVCGen/RelationalPowerOfTwoAnalyser.cs
+++ b/GPUVerifyVCGen/RelationalPowerOfTwoAnalyser.cs
@@ -167,7 +167,8 @@ namespace GPUVerify
         {
             if (!(v.TypedIdent.Type.Equals(verifier.IntRep.GetIntType(8))
                 || v.TypedIdent.Type.Equals(verifier.IntRep.GetIntType(16))
-                || v.TypedIdent.Type.Equals(verifier.IntRep.GetIntType(32))))
+                || v.TypedIdent.Type.Equals(verifier.IntRep.GetIntType(32))
+                || v.TypedIdent.Type.Equals(verifier.IntRep.GetIntType(64))))
             {
                 return Kind.No;
             }

--- a/GPUVerifyVCGen/StrideConstraint.cs
+++ b/GPUVerifyVCGen/StrideConstraint.cs
@@ -16,8 +16,8 @@ namespace GPUVerify
         public static StrideConstraint Bottom(GPUVerifier verifier, Expr e)
         {
             return new ModStrideConstraint(
-                verifier.IntRep.GetLiteral(1, e.Type is BvType ? e.Type.BvBits : verifier.SizeTBits),
-                verifier.Zero(e.Type is BvType ? e.Type.BvBits : verifier.SizeTBits));
+                verifier.IntRep.GetLiteral(1, e.Type),
+                verifier.IntRep.GetZero(e.Type));
         }
 
         public bool IsBottom()

--- a/GPUVerifyVCGen/WatchdogRaceInstrumenter.cs
+++ b/GPUVerifyVCGen/WatchdogRaceInstrumenter.cs
@@ -34,16 +34,16 @@ namespace GPUVerify
             Debug.Assert(mt.Arguments.Count == 1);
 
             Variable accessHasOccurredVariable = GPUVerifier.MakeAccessHasOccurredVariable(v.Name, access);
-            Variable accessOffsetVariable = RaceInstrumentationUtil.MakeOffsetVariable(v.Name, access, Verifier.IntRep.GetIntType(Verifier.SizeTBits));
+            Variable accessOffsetVariable = RaceInstrumentationUtil.MakeOffsetVariable(v.Name, access, Verifier.SizeTType);
             Variable accessValueVariable = RaceInstrumentationUtil.MakeValueVariable(v.Name, access, mt.Result);
             Variable accessBenignFlagVariable = GPUVerifier.MakeBenignFlagVariable(v.Name);
-            Variable accessAsyncHandleVariable = RaceInstrumentationUtil.MakeAsyncHandleVariable(v.Name, access, Verifier.IntRep.GetIntType(Verifier.SizeTBits));
+            Variable accessAsyncHandleVariable = RaceInstrumentationUtil.MakeAsyncHandleVariable(v.Name, access, Verifier.SizeTType);
 
             Variable predicateParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_P", Type.Bool));
             Variable offsetParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_offset", mt.Arguments[0]));
             Variable valueParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_value", mt.Result));
             Variable valueOldParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_value_old", mt.Result));
-            Variable asyncHandleParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_async_handle", Verifier.IntRep.GetIntType(Verifier.SizeTBits)));
+            Variable asyncHandleParameter = new LocalVariable(Token.NoToken, new TypedIdent(Token.NoToken, "_async_handle", Verifier.SizeTType));
 
             Debug.Assert(!(mt.Result is MapType));
 

--- a/testsuite/OpenCL/pow2/64bit_loopcounter/kernel.cl
+++ b/testsuite/OpenCL/pow2/64bit_loopcounter/kernel.cl
@@ -1,0 +1,9 @@
+//pass
+//--local_size=32 --num_groups=2
+
+__kernel void foo(__global double *A, int n)
+{
+  for(long i = n; i > 0; i >>= 1) {
+    A[get_global_id(0)] = 0.0;
+  }
+}

--- a/testsuite/OpenCL/pow2/64bit_relational/kernel.cl
+++ b/testsuite/OpenCL/pow2/64bit_relational/kernel.cl
@@ -1,0 +1,11 @@
+//pass
+//--local_size=32 --num_groups=2
+
+__kernel void foo(__global double *A, int n)
+{
+  long j = 1;
+  for(long i = n; i > 0; i >>= 1) {
+    A[get_global_id(0)] = 0.0;
+    j *= 2;
+  }
+}


### PR DESCRIPTION
The power-of-2 invariants have always been broken for anything but 32-bit loop counters. This didn't show, because invariant speculation was not triggering for 64-bit counters until commit e44ff0070 This was triggered by one of the polybench kernels using a 64-bit loop counter.