### PR TITLE
Adding support for CUDA Cooperative Groups API

### DIFF
--- a/GPUVerifyLib/GPUVerifyErrorReporter.cs
+++ b/GPUVerifyLib/GPUVerifyErrorReporter.cs
@@ -534,10 +534,10 @@ namespace GPUVerify
 
         protected static void PopulateModelWithStatesIfNecessary(Counterexample cex)
         {
-            if (!cex.Model.ModelHasStatesAlready)
+            if (!cex.ModelHasStatesAlready)
             {
                 cex.PopulateModelWithStates();
-                cex.Model.ModelHasStatesAlready = true;
+                cex.ModelHasStatesAlready = true;
             }
         }
 

--- a/GPUVerifyLib/GPUVerifyErrorReporter.cs
+++ b/GPUVerifyLib/GPUVerifyErrorReporter.cs
@@ -19,7 +19,7 @@ namespace GPUVerify
     using Microsoft.Boogie;
     using Microsoft.Boogie.GraphUtil;
 
-    internal class GPUVerifyErrorReporter
+    public class GPUVerifyErrorReporter
     {
         private enum ErrorMsgType
         {
@@ -517,7 +517,7 @@ namespace GPUVerify
                 "captureState");
         }
 
-        private static string GetStateName(CallCounterexample callCex)
+        protected static string GetStateName(CallCounterexample callCex)
         {
             return GetStateName(callCex.FailingCall.Attributes, callCex);
         }
@@ -527,21 +527,21 @@ namespace GPUVerify
             return GetStateName(assertCex.FailingAssert.Attributes, assertCex);
         }
 
-        private static string GetSourceFileName()
+        protected static string GetSourceFileName()
         {
             return CommandLineOptions.Clo.Files[CommandLineOptions.Clo.Files.Count() - 1];
         }
 
-        private static void PopulateModelWithStatesIfNecessary(Counterexample cex)
+        protected static void PopulateModelWithStatesIfNecessary(Counterexample cex)
         {
-            if (!cex.ModelHasStatesAlready)
+            if (!cex.Model.ModelHasStatesAlready)
             {
                 cex.PopulateModelWithStates();
-                cex.ModelHasStatesAlready = true;
+                cex.Model.ModelHasStatesAlready = true;
             }
         }
 
-        private static void DetermineNatureOfRace(CallCounterexample callCex, out string raceName, out string access1, out string access2)
+        protected static void DetermineNatureOfRace(CallCounterexample callCex, out string raceName, out string access1, out string access2)
         {
             if (QKeyValue.FindBoolAttribute(callCex.FailingRequires.Attributes, "write_read"))
             {
@@ -594,7 +594,7 @@ namespace GPUVerify
             }
         }
 
-        private IEnumerable<SourceLocationInfo> GetPossibleSourceLocationsForFirstAccessInRace(CallCounterexample callCex, string arrayName, AccessType accessType, string raceyState)
+        protected IEnumerable<SourceLocationInfo> GetPossibleSourceLocationsForFirstAccessInRace(CallCounterexample callCex, string arrayName, AccessType accessType, string raceyState)
         {
             string accessHasOccurred = RaceInstrumentationUtil.MakeHasOccurredVariableName(arrayName, accessType);
             string accessOffset = RaceInstrumentationUtil.MakeOffsetVariableName(arrayName, accessType);
@@ -802,7 +802,7 @@ namespace GPUVerify
             }
         }
 
-        private static QKeyValue GetAttributes(Absy a)
+        protected static QKeyValue GetAttributes(Absy a)
         {
             if (a is PredicateCmd)
                 return (a as PredicateCmd).Attributes;
@@ -1100,7 +1100,7 @@ namespace GPUVerify
             }
         }
 
-        private static string GetArrayName(Requires requires)
+        protected static string GetArrayName(Requires requires)
         {
             string arrName = QKeyValue.FindStringAttribute(requires.Attributes, "array");
             Debug.Assert(arrName != null);

--- a/GPUVerifyLib/SourceLocationInfo.cs
+++ b/GPUVerifyLib/SourceLocationInfo.cs
@@ -222,6 +222,11 @@ namespace GPUVerify
             return records[0];
         }
 
+        public List<Record> GetRecords()
+        {
+            return records;
+        }
+
         public void PrintStackTrace()
         {
             Utilities.IO.ErrorWriteLine(TrimLeadingSpaces(FetchCodeLine(0), 2));

--- a/GPUVerifyVCGen/BarrierIntervalsAnalysis.cs
+++ b/GPUVerifyVCGen/BarrierIntervalsAnalysis.cs
@@ -52,7 +52,7 @@ namespace GPUVerify
         {
             HashSet<BarrierInterval> result = new HashSet<BarrierInterval>();
 
-            ExtractCommandsIntoBlocks(impl, item => (item is CallCmd && GPUVerifier.IsBarrier(((CallCmd)item).Proc)));
+            ExtractCommandsIntoBlocks(impl, item => item is CallCmd && GPUVerifier.IsBarrier(((CallCmd)item).Proc));
             Graph<Block> cfg = Program.GraphFromImpl(impl);
 
             // If the CFG has no exit nodes, i.e. it cannot terminate,
@@ -146,6 +146,10 @@ namespace GPUVerify
                 // Also we may be able to do better in this case, but for now we conservatively say no
                 return false;
             }
+
+            // skip the barrier strength check for grid-level barriers
+            if (GPUVerifier.IsGridBarrier(c.Proc))
+                return true;
 
             Debug.Assert(c.Ins.Count() == 2);
             if (strength == BarrierStrength.GROUP_SHARED || strength == BarrierStrength.ALL)

--- a/GPUVerifyVCGen/IRaceInstrumenter.cs
+++ b/GPUVerifyVCGen/IRaceInstrumenter.cs
@@ -21,7 +21,7 @@ namespace GPUVerify
 
         void AddRaceCheckingDeclarations();
 
-        BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition);
+        BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition, bool gridBarrier = false);
 
         void AddRaceCheckingCandidateRequires(Procedure proc);
 

--- a/GPUVerifyVCGen/NullRaceInstrumenter.cs
+++ b/GPUVerifyVCGen/NullRaceInstrumenter.cs
@@ -26,7 +26,7 @@ namespace GPUVerify
         {
         }
 
-        public Microsoft.Boogie.BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition)
+        public Microsoft.Boogie.BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition, bool gridBarrier = false)
         {
             return new BigBlock(Token.NoToken, null, new List<Cmd>(), null, null);
         }

--- a/GPUVerifyVCGen/RaceInstrumenter.cs
+++ b/GPUVerifyVCGen/RaceInstrumenter.cs
@@ -929,7 +929,7 @@ namespace GPUVerify
             return newProcedure;
         }
 
-        public BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition)
+        public BigBlock MakeResetReadWriteSetStatements(Variable v, Expr resetCondition, bool gridBarrier = false)
         {
             // We only want to do this reset for enabled arrays
             Debug.Assert(Verifier.KernelArrayInfo.GetGlobalAndGroupSharedArrays(false).Contains(v));
@@ -941,8 +941,10 @@ namespace GPUVerify
                 Expr resetAssumeGuard = Expr.Imp(
                     resetCondition, Expr.Not(Expr.Ident(GPUVerifier.MakeAccessHasOccurredVariable(v.Name, kind))));
 
+                // we don't need the group check for a grid-level barrier
+                Expr groupCheck = gridBarrier == false ? Verifier.ThreadsInSameGroup() : Expr.True;
                 if (Verifier.KernelArrayInfo.GetGlobalArrays(false).Contains(v))
-                    resetAssumeGuard = Expr.Imp(Verifier.ThreadsInSameGroup(), resetAssumeGuard);
+                    resetAssumeGuard = Expr.Imp(groupCheck, resetAssumeGuard);
 
                 if (new AccessType[] { AccessType.READ, AccessType.WRITE }.Contains(kind)
                   && Verifier.ArraysAccessedByAsyncWorkGroupCopy[kind].Contains(v.Name))


### PR DESCRIPTION
As a part of our work (@cs17resch01003 and @sbjoshi) on GPURepair (https://arxiv.org/abs/2011.08373), we have extended Bugle and GPUVerify to support the CUDA Cooperative Groups API (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cooperative-groups). This pull request depends on https://github.com/mc-imperial/bugle/pull/8. There are two changes in this pull request:
1. We have changed the access modifiers of the GPUVerifyErrorReporter class and some methods in it so that it can be extended in GPURepair
2. To support grid-level synchronization, we have added code to GPUVerify such that the shared variables can be havoced without checking if the threads belong to the same group. We have included comments wherever we have made a code change, please take a look

We have tried to maintain the same code formatting as that of the existing code. Please let us know if any changes are needed or if there are any questions.

One thing we noticed is that the Travis build configuration checks out the code for libclc from version bac1578088e of https://git.llvm.org/git/libclc.git/ which doesn't exist anymore. For GPURepair, we are using https://github.com/llvm/llvm-project/tree/release/8.x/libclc which we believe is the closest to the checked-out version. With that change one of the test cases ([OpenCL/pointeranalysistests/manyprocedures](https://github.com/mc-imperial/gpuverify/blob/master/testsuite/OpenCL/pointeranalysistests/manyprocedures/kernel.cl)) is failing. GPUverify is able to identify null pointer accesses and write-write races for this kernel. This test case is failing even without our code changes. Attaching the [output](https://github.com/mc-imperial/gpuverify/files/7278836/manyprocedures.log) from GPUVerify. Please let us know if any further investigation is needed from our side.