### PR TITLE
Changing Access Modifiers

### DIFF
--- a/GPUVerifyLib/GPUVerifyErrorReporter.cs
+++ b/GPUVerifyLib/GPUVerifyErrorReporter.cs
@@ -19,7 +19,7 @@ namespace GPUVerify
     using Microsoft.Boogie;
     using Microsoft.Boogie.GraphUtil;
 
-    internal class GPUVerifyErrorReporter
+    public class GPUVerifyErrorReporter
     {
         private enum ErrorMsgType
         {
@@ -517,7 +517,7 @@ namespace GPUVerify
                 "captureState");
         }
 
-        private static string GetStateName(CallCounterexample callCex)
+        protected static string GetStateName(CallCounterexample callCex)
         {
             return GetStateName(callCex.FailingCall.Attributes, callCex);
         }
@@ -527,12 +527,12 @@ namespace GPUVerify
             return GetStateName(assertCex.FailingAssert.Attributes, assertCex);
         }
 
-        private static string GetSourceFileName()
+        protected static string GetSourceFileName()
         {
             return CommandLineOptions.Clo.Files[CommandLineOptions.Clo.Files.Count() - 1];
         }
 
-        private static void PopulateModelWithStatesIfNecessary(Counterexample cex)
+        protected static void PopulateModelWithStatesIfNecessary(Counterexample cex)
         {
             if (!cex.ModelHasStatesAlready)
             {
@@ -541,7 +541,7 @@ namespace GPUVerify
             }
         }
 
-        private static void DetermineNatureOfRace(CallCounterexample callCex, out string raceName, out string access1, out string access2)
+        protected static void DetermineNatureOfRace(CallCounterexample callCex, out string raceName, out string access1, out string access2)
         {
             if (QKeyValue.FindBoolAttribute(callCex.FailingRequires.Attributes, "write_read"))
             {
@@ -594,7 +594,7 @@ namespace GPUVerify
             }
         }
 
-        private IEnumerable<SourceLocationInfo> GetPossibleSourceLocationsForFirstAccessInRace(CallCounterexample callCex, string arrayName, AccessType accessType, string raceyState)
+        protected IEnumerable<SourceLocationInfo> GetPossibleSourceLocationsForFirstAccessInRace(CallCounterexample callCex, string arrayName, AccessType accessType, string raceyState)
         {
             string accessHasOccurred = RaceInstrumentationUtil.MakeHasOccurredVariableName(arrayName, accessType);
             string accessOffset = RaceInstrumentationUtil.MakeOffsetVariableName(arrayName, accessType);
@@ -802,7 +802,7 @@ namespace GPUVerify
             }
         }
 
-        private static QKeyValue GetAttributes(Absy a)
+        protected static QKeyValue GetAttributes(Absy a)
         {
             if (a is PredicateCmd)
                 return (a as PredicateCmd).Attributes;
@@ -1100,7 +1100,7 @@ namespace GPUVerify
             }
         }
 
-        private static string GetArrayName(Requires requires)
+        protected static string GetArrayName(Requires requires)
         {
             string arrName = QKeyValue.FindStringAttribute(requires.Attributes, "array");
             Debug.Assert(arrName != null);

--- a/GPUVerifyLib/SourceLocationInfo.cs
+++ b/GPUVerifyLib/SourceLocationInfo.cs
@@ -222,6 +222,11 @@ namespace GPUVerify
             return records[0];
         }
 
+        public List<Record> GetRecords()
+        {
+            return records;
+        }
+
         public void PrintStackTrace()
         {
             Utilities.IO.ErrorWriteLine(TrimLeadingSpaces(FetchCodeLine(0), 2));


### PR DESCRIPTION
As suggested in mc-imperial/gpuverify#38, we have broken the PR into two parts. This pull request includes the changes to the access modifiers of the GPUVerifyErrorReporter class and some methods in it so that it can be extended in our (@cs17resch01003 and @sbjoshi) work on GPURepair (https://arxiv.org/abs/2011.08373), We have also added a public method in the SourceLocationInfo class to expose the records that make up the source location.

We have tried to maintain the same code formatting as that of the existing code. Please let us know if any changes are needed or if there are any questions.

One thing we noticed is that the Travis build configuration checks out the code for libclc from version bac1578088e of https://git.llvm.org/git/libclc.git/ which doesn't exist anymore. For GPURepair, we are using https://github.com/llvm/llvm-project/tree/release/8.x/libclc which we believe is the closest to the checked-out version. With that change one of the test cases (OpenCL/pointeranalysistests/manyprocedures) is failing. GPUVerify is able to identify null pointer accesses and write-write races for this kernel. This test case is failing even without our code changes. Attaching the [output ](https://github.com/mc-imperial/gpuverify/files/7278836/manyprocedures.log) from GPUVerify. Please let us know if any further investigation is needed from our side.